### PR TITLE
refactor: use unique process name based on network

### DIFF
--- a/packages/cli/src/commands/command.ts
+++ b/packages/cli/src/commands/command.ts
@@ -102,7 +102,7 @@ export abstract class BaseCommand extends Command {
         }
     }
 
-    protected getProcessName(): string {
-        return "multisig-server";
+    protected getProcessName(network: string): string {
+        return `multisig-server-${network}`;
     }
 }

--- a/packages/cli/src/commands/log.ts
+++ b/packages/cli/src/commands/log.ts
@@ -12,6 +12,7 @@ export class LogCommand extends BaseCommand {
     public static examples: string[] = [`$ multisig-server log`];
 
     public static flags: CommandFlags = {
+        ...BaseCommand.flagsConfiguration,
         error: flags.boolean({
             description: "only show error output",
         }),
@@ -23,8 +24,8 @@ export class LogCommand extends BaseCommand {
 
     public async run(): Promise<void> {
         const { flags } = this.parse(LogCommand);
-        
-        const processName: string = this.getProcessName();
+
+        const processName: string = this.getProcessName(flags.network as string);
 
         this.abortMissingProcess(processName);
 

--- a/packages/cli/src/commands/restart.ts
+++ b/packages/cli/src/commands/restart.ts
@@ -1,5 +1,6 @@
 import cli from "cli-ux";
 import { processManager } from "../process-manager";
+import { CommandFlags } from "../types";
 import { BaseCommand } from "./command";
 
 export class RestartCommand extends BaseCommand {
@@ -11,8 +12,14 @@ $ multisig-server restart
 `,
     ];
 
+    public static flags: CommandFlags = {
+        ...BaseCommand.flagsConfiguration,
+    };
+
     public async run(): Promise<void> {
-        const processName: string = this.getProcessName();
+        const { flags } = this.parse(RestartCommand);
+
+        const processName: string = this.getProcessName(flags.network as string);
 
         try {
             this.abortMissingProcess(processName);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -25,7 +25,7 @@ $ multisig-server start
     public async run(): Promise<void> {
         const { flags } = this.parse(StartCommand);
 
-        const processName: string = this.getProcessName();
+        const processName: string = this.getProcessName(flags.network as string);
 
         this.abortRunningProcess(processName);
 

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -3,7 +3,7 @@ import dayjs from "dayjs";
 import prettyBytes from "pretty-bytes";
 import prettyMs from "pretty-ms";
 import { processManager } from "../process-manager";
-import { ProcessDescription } from "../types";
+import { CommandFlags, ProcessDescription } from "../types";
 import { renderTable } from "../utils";
 import { BaseCommand } from "./command";
 
@@ -12,8 +12,14 @@ export class StatusCommand extends BaseCommand {
 
     public static examples: string[] = [`$ multisig-server status`];
 
+    public static flags: CommandFlags = {
+        ...BaseCommand.flagsConfiguration,
+    };
+
     public async run(): Promise<void> {
-        const processName: string = this.getProcessName();
+        const { flags } = this.parse(StatusCommand);
+
+        const processName: string = this.getProcessName(flags.network as string);
 
         this.abortMissingProcess(processName);
 

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -14,6 +14,7 @@ $ multisig-server stop
     ];
 
     public static flags: CommandFlags = {
+        ...BaseCommand.flagsConfiguration,
         kill: flags.boolean({
             description: "kill the process or daemon",
         }),
@@ -22,7 +23,7 @@ $ multisig-server stop
     public async run(): Promise<void> {
         const { flags } = this.parse(StopCommand);
 
-        const processName: string = this.getProcessName();
+        const processName: string = this.getProcessName(flags.network as string);
 
         try {
             this.abortMissingProcess(processName);

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -11,6 +11,7 @@ export class UpdateCommand extends BaseCommand {
     public static description: string = "Update the MultiSignature server installation";
 
     public static flags: CommandFlags = {
+        ...BaseCommand.flagsConfiguration,
         force: flags.boolean({
             description: "force an update",
         }),
@@ -67,6 +68,6 @@ export class UpdateCommand extends BaseCommand {
 
         this.warn(`Version ${state.updateVersion} has been installed.`);
 
-        await this.restartRunningProcessPrompt(this.getProcessName(), !flags.restart);
+        await this.restartRunningProcessPrompt(this.getProcessName(flags.network), !flags.restart);
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Generate a unique process name based on the network to allow multiple instances on the same server, assuming different ports are used.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
