### PR TITLE
fix: always enable AIP11

### DIFF
--- a/packages/server/src/server/index.ts
+++ b/packages/server/src/server/index.ts
@@ -63,6 +63,7 @@ export async function startServer(options: Record<string, string | number | bool
     });
 
     Managers.configManager.setFromPreset(options.network as Types.NetworkName);
+    Managers.configManager.getMilestone().aip11 = true;
 
     server.route({
         method: "GET",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This is a temporary fix for the below issue. The permanent solution will be to retrieve the network height and handle any issues if AIP11 is not active on a network.

```
8|multisig-server-devnet  | TransactionVersionError: Version 2 not supported.
8|multisig-server-devnet  |     at Function.getBytes (~/multisig-server/node_modules/@arkecosystem/crypto/dist/transactions/serializer.js:28:19)
8|multisig-server-devnet  |     at Function.toHash (~/multisig-server/node_modules/@arkecosystem/crypto/dist/transactions/utils.js:12:71)
8|multisig-server-devnet  |     at Function.getId (~/multisig-server/node_modules/@arkecosystem/crypto/dist/transactions/utils.js:15:26)
8|multisig-server-devnet  |     at Object.exports.getBaseTransactionId (~/multisig-server/packages/server/dist/server/utils.js:11:40)
8|multisig-server-devnet  |     at Memory.saveTransaction (~/multisig-server/packages/server/dist/services/memory.js:14:33)
8|multisig-server-devnet  |     at Memory.loadTransactions (~/multisig-server/packages/server/dist/services/memory.js:69:18)
8|multisig-server-devnet  |     at initDatabaseSync (~/multisig-server/packages/server/dist/server/index.js:22:21)
8|multisig-server-devnet  |     at Object.startServer (~/multisig-server/packages/server/dist/server/index.js:106:5)
```

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
