### PR TITLE
chore: include network name in sqlite db name

### DIFF
--- a/__tests__/server/server.test.ts
+++ b/__tests__/server/server.test.ts
@@ -1,0 +1,63 @@
+import "jest-extended";
+
+import { Managers, Transactions } from "@arkecosystem/crypto";
+import { Server } from "@hapi/hapi";
+import fs from "fs-extra";
+import got from "got";
+import * as mocks from "../__mocks__/transaction";
+import { launchServer } from "../__support__";
+
+// the name of sqlite db that is used for saving/restoring tx on stop/start
+const sqliteName = "transactions-storage-testnet.sqlite";
+let server: Server;
+beforeAll(async () => {
+    fs.removeSync(sqliteName);
+
+    server = await launchServer();
+    Managers.configManager.setFromPreset("testnet");
+});
+afterAll(async () => {
+    await server.stop();
+    fs.removeSync(sqliteName);
+});
+
+describe("Server", () => {
+    describe("Server stop and restart", () => {
+        it("should save the transactions to the disk when stopping and restore them when restarting", async () => {
+            const transaction = Transactions.BuilderFactory.multiSignature()
+                .multiSignatureAsset(mocks.multisigAsset)
+                .network(23)
+                .sign(mocks.passphrase)
+                .multiSign(mocks.passphrase, 0)
+                .multiSign(mocks.passphrases[1], 1)
+                .getStruct();
+            await got.post(`http://localhost:8080/transaction`, {
+                body: JSON.stringify({
+                    data: transaction,
+                    multisigAsset: mocks.multisigAsset,
+                }),
+            });
+
+            const response = await got.get(`http://localhost:8080/transactions?publicKey=${mocks.publicKey}`);
+            const body = JSON.parse(response.body);
+            expect(body).toBeArrayOfSize(1);
+            expect(body[0].data).toEqual(JSON.parse(JSON.stringify(transaction)));
+            expect(body[0].multisigAsset).toEqual(mocks.multisigAsset);
+            expect(body[0]).toHaveProperty("timestamp");
+
+            await server.stop();
+
+            expect(fs.existsSync(sqliteName)).toBeTrue(); // transactions should be saved here
+
+            server = await launchServer();
+            const responseAfterRestart = await got.get(
+                `http://localhost:8080/transactions?publicKey=${mocks.publicKey}`,
+            );
+            const bodyAfterRestart = JSON.parse(responseAfterRestart.body);
+            expect(bodyAfterRestart).toBeArrayOfSize(1);
+            expect(bodyAfterRestart[0].data).toEqual(JSON.parse(JSON.stringify(transaction)));
+            expect(bodyAfterRestart[0].multisigAsset).toEqual(mocks.multisigAsset);
+            expect(bodyAfterRestart[0]).toHaveProperty("timestamp");
+        });
+    });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -12,7 +12,7 @@ export const start = async (options: { server: Record<string, any>; logger?: any
     const server = await startServer(options.server);
 
     const exit = () => {
-        exitHandler();
+        exitHandler(options.server.network);
         server.stop();
     };
     process.on("exit", exit);

--- a/packages/server/src/server/index.ts
+++ b/packages/server/src/server/index.ts
@@ -9,9 +9,9 @@ import { TransactionStatus } from "./enums";
 import * as handlers from "./handlers";
 import { transactionSchemaVerifier } from "./transaction-schema-verifier";
 
-const initDatabaseSync = () => {
+const initDatabaseSync = (network: string) => {
     const storage = new Storage();
-    storage.connect("transactions-storage.sqlite");
+    storage.connect(`transactions-storage-${network}.sqlite`);
 
     const transactions = storage.loadAll();
     memory.loadTransactions(transactions);
@@ -89,7 +89,7 @@ export async function startServer(options: Record<string, string | number | bool
         handler: handlers.deleteTransactions,
     });
 
-    initDatabaseSync();
+    initDatabaseSync(options.network as string);
 
     await server.start();
 
@@ -98,9 +98,9 @@ export async function startServer(options: Record<string, string | number | bool
     return server;
 }
 
-export const exitHandler = () => {
+export const exitHandler = (network: string) => {
     const storage = new Storage();
-    storage.connect("transactions-storage.sqlite");
+    storage.connect(`transactions-storage-${network}.sqlite`);
 
     const memTransactions = memory.getAllTransactions();
     storage.deleteAll();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
In order to be able to run multiple instances of the multisig server by network, the sqlite database name that we use should include the network name. (or we can end up restoring transactions from a different network)

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
