### PR TITLE
feat: add network height cli parameter

### DIFF
--- a/packages/cli/src/commands/command.ts
+++ b/packages/cli/src/commands/command.ts
@@ -20,6 +20,10 @@ export abstract class BaseCommand extends Command {
             default: "testnet",
             options: Object.keys(Networks),
         }),
+        height: flags.integer({
+            description: "the height to load in the network milestone(s)",
+            default: 1,
+        }),
     };
 
     protected flagsToStrings(flags: CommandFlags, ignoreKeys: string[] = []): string {

--- a/packages/server/src/server/index.ts
+++ b/packages/server/src/server/index.ts
@@ -34,6 +34,7 @@ export async function startServer(options: Record<string, string | number | bool
     });
 
     Managers.configManager.setFromPreset(options.network as Types.NetworkName);
+    Managers.configManager.setHeight(options.height as number);
     Managers.configManager.getMilestone().aip11 = true;
 
     server.route({


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The height allows the multisig-server to load in network milestones (e.g. vendorfield length)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
